### PR TITLE
Use regular expressions to generate the prompt.

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -21,6 +21,7 @@ interface Config {
   'CTR Threshold': number;
   'Impression Threshold': number;
   'ImgGen Prompt': string;
+  'ImgGen Prompt Suffix': string;
   'Number of images per Ad Group': number;
   'Number of images per API call': number;
   'GCP Project': string;
@@ -42,6 +43,7 @@ const DEFAULT_CONFIG = {
   'CTR Threshold': 0,
   'Impression Threshold': 0,
   'ImgGen Prompt': '${name}',
+  'ImgGen Prompt Suffix': 'HDR, taken by professional',
   'Number of images per Ad Group': 0,
   'Number of images per API call': 0,
   'GCP Project': '',

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,6 +30,7 @@ interface Config {
   'Bad performance DIR': string;
   'Uploaded DIR': string;
   'Generated DIR': string;
+  'Ad Group Name Regex': string;
 }
 
 const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('Config');
@@ -40,7 +41,7 @@ const DEFAULT_CONFIG = {
   'Campaign IDs': '',
   'CTR Threshold': 0,
   'Impression Threshold': 0,
-  'ImgGen Prompt': '',
+  'ImgGen Prompt': '${name}',
   'Number of images per Ad Group': 0,
   'Number of images per API call': 0,
   'GCP Project': '',
@@ -50,6 +51,7 @@ const DEFAULT_CONFIG = {
   'Bad performance DIR': '',
   'Uploaded DIR': '',
   'Generated DIR': '',
+  'Ad Group Name Regex': '^(?<name>.*)$', // capture everything by default
 };
 
 export const CONFIG: Config =

--- a/src/image-generation-service.ts
+++ b/src/image-generation-service.ts
@@ -70,10 +70,16 @@ export class ImageGenerationService {
         prompt = this.createPrompt(matchGroups);
       } else {
         Logger.log(
-          `No matching groups found for ${adGroup.adGroup.name} with ${regex}. Using full prompt.`);
+          `No matching groups found for ${adGroup.adGroup.name} with ${regex}. Using full prompt.`
+        );
         prompt = CONFIG['ImgGen Prompt'];
       }
-      const images = this._vertexAiApi.callVisionApi(adGroup.adGroup.name, prompt, imgCount);
+
+      if (CONFIG['ImgGen Prompt Suffix']) {
+        prompt += ', ' + CONFIG['ImgGen Prompt Suffix'];
+      }
+
+      const images = this._vertexAiApi.callVisionApi(prompt, imgCount);
       Logger.log(
         `Received ${images?.length || 0} images for ${adGroup.adGroup.name}(${
           adGroup.adGroup.id
@@ -103,7 +109,7 @@ export class ImageGenerationService {
   /**
    * For a given string & regex return the match groups if they exist else null
    */
-  getRegexMatchGroups(str, regex) {
+  getRegexMatchGroups(str: string, regex: RegExp) {
     const regexMatch = str.match(regex);
     if (regexMatch !== null) {
       return regexMatch.groups;
@@ -118,7 +124,7 @@ export class ImageGenerationService {
    * If an object with { 'city': 'London' } is provided it will replace the
    * placeholder and return "A photo of a London in sharp, 4k".
    */
-  createPrompt(obj) {
+  createPrompt(obj: { [key: string]: string }) {
     let prompt = CONFIG['ImgGen Prompt'];
     for (const [key, value] of Object.entries(obj)) {
       prompt = prompt.replaceAll('${' + key + '}', value);

--- a/src/image-generation-service.ts
+++ b/src/image-generation-service.ts
@@ -74,11 +74,6 @@ export class ImageGenerationService {
         prompt = CONFIG['ImgGen Prompt'];
       }
       const images = this._vertexAiApi.callVisionApi(adGroup.adGroup.name, prompt, imgCount);
-      const images = this._vertexAiApi.callVisionApi(
-        adGroup.adGroup.name,
-        CONFIG['ImgGen Prompt'],
-        imgCount
-      );
       Logger.log(
         `Received ${images?.length || 0} images for ${adGroup.adGroup.name}(${
           adGroup.adGroup.id
@@ -126,8 +121,7 @@ export class ImageGenerationService {
   createPrompt(obj) {
     let prompt = CONFIG['ImgGen Prompt'];
     for (const [key, value] of Object.entries(obj)) {
-      const regex = new RegExp('(\\${' + key + '})', 'gi');
-      prompt = prompt.replaceAll(regex, value);
+      prompt = prompt.replaceAll('${' + key + '}', value);
     }
     return prompt;
   }

--- a/src/vertex-ai-api.ts
+++ b/src/vertex-ai-api.ts
@@ -39,15 +39,11 @@ export class VertexAiApi {
     };
   }
 
-  callVisionApi(
-    topic: string,
-    prompt: string,
-    sampleCount = 8,
-    sampleImageSize = '1024'
-  ) {
+  callVisionApi(prompt: string, sampleCount = 8, sampleImageSize = '1024') {
+    console.log('prompt', prompt);
     const options = Object.assign({}, this._baseOptions);
     const payload = {
-      instances: [{ prompt: `${topic},${prompt}` }],
+      instances: [{ prompt }],
       parameters: {
         sampleImageSize,
         sampleCount,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,10 @@
   "compilerOptions": {
     "target": "es2020",
     "module": "es2020",
-    "lib": ["es2020"],
+    "lib": [
+      "es2020",
+      "ES2021.String"
+    ],
     "moduleResolution": "node",
     "outDir": "dist",
     "rootDir": ".",


### PR DESCRIPTION
The name of the ad group can sometimes contain a lot more info than is needed, and sometimes we want to extract parts of it, e.g. a location.

This change will allow you to use named capturing groups in regular expressions, and combine those in the prompt, allowing for more complex prompt generation.

For example if an adgroup is named `EN_UK_London_generic` you could use `^(?<language>[a-zA-Z]{2})_(?<country>[a-zA-Z]+)_(?<city>[a-zA-Z]+)` to capture the various fields, and create a prompt with `A photo of a landmark in ${city}, ${country}`.