### PR TITLE
Add image slider to the UI to enable resizing images.

### DIFF
--- a/src/ui/src/app/app.component.css
+++ b/src/ui/src/app/app.component.css
@@ -44,3 +44,7 @@ mat-toolbar {
   top: 0;
   z-index: 1000;
 }
+
+mat-slider {
+  width: 150px;
+}

--- a/src/ui/src/app/app.component.html
+++ b/src/ui/src/app/app.component.html
@@ -16,6 +16,15 @@ limitations under the License.
 <mat-toolbar color="primary">
   <span>Adios</span>
   <span class="spacer"></span>
+  <mat-slider color="accent"
+    id="image-slider"
+    min="1"
+    max="5"
+    step="1"
+    (value)="imageSize"
+    (change)="resizeImages($event)">
+    <input matSliderThumb>
+  </mat-slider>
   <button
     mat-icon-button
     matTooltip="Validate selected images"
@@ -61,6 +70,7 @@ limitations under the License.
         <image-extension
           *ngFor="let img of row.images"
           [image]="img"
+          [imageSize]="imageSize"
           (click)="toggleImage(img)"
         />
       </mat-card-content>

--- a/src/ui/src/app/app.component.ts
+++ b/src/ui/src/app/app.component.ts
@@ -25,6 +25,7 @@ import {
   PageEvent,
 } from '@angular/material/paginator';
 import { MatCardModule } from '@angular/material/card';
+import { MatSliderModule } from '@angular/material/slider';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { ApiCallsService } from './api-calls/api-calls.service';
 import { environment } from '../environments/environment';
@@ -45,6 +46,7 @@ import { ImageExtensionComponent } from './image-extension/image-extension.compo
     MatIconModule,
     MatPaginatorModule,
     MatProgressBarModule,
+    MatSliderModule,
     MatToolbarModule,
     MatTooltipModule,
     ImageExtensionComponent,
@@ -59,6 +61,7 @@ export class AppComponent implements OnInit {
   adGroups: AdGroup[] = [];
   data: AdGroup[] = [];
   selectedImages: Image[] = [];
+  imageSize: number = 1;
 
   constructor(private apiCallsService: ApiCallsService) {
     this.env = environment.production;
@@ -132,5 +135,9 @@ export class AppComponent implements OnInit {
       e.pageIndex * e.pageSize,
       (e.pageIndex + 1) * e.pageSize
     );
+  };
+
+  resizeImages = (e: Event) => {
+    this.imageSize = (e.target as HTMLInputElement).valueAsNumber;
   };
 }

--- a/src/ui/src/app/image-extension/image-extension.component.html
+++ b/src/ui/src/app/image-extension/image-extension.component.html
@@ -13,12 +13,14 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<div style="position: relative">
+<div
+  style="position: relative"
+  [style.width]="getImageSize()"
+  [style.height]="getImageSize()">
   <img
     ngSrc="{{ image.url }}"
     alt="{{ image.filename }}"
-    width="128"
-    height="128"
+    fill="true"
     [class.selected]="image.selected"
     priority
   />

--- a/src/ui/src/app/image-extension/image-extension.component.ts
+++ b/src/ui/src/app/image-extension/image-extension.component.ts
@@ -28,6 +28,7 @@ import { Image, IMAGE_STATUS } from '../api-calls/api-calls.service.interface';
 })
 export class ImageExtensionComponent {
   @Input({ required: true }) image!: Image;
+  @Input() imageSize: number = 1;
 
   getIcon = (status: IMAGE_STATUS) => {
     switch (status) {
@@ -67,5 +68,10 @@ export class ImageExtensionComponent {
     return `
       Image: ${image.filename}
       Status: ${image.status}`;
+  };
+
+  getImageSize = () => {
+    const baseSize = 128;
+    return `${baseSize * this.imageSize}px`;
   };
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
     "module": "es2020",
     "lib": [
       "es2020",
-      "ES2021.String"
+      "ES2021.String",
+      "dom"
     ],
     "moduleResolution": "node",
     "outDir": "dist",


### PR DESCRIPTION
By default the images in the UI are a fixed size. This makes it hard to fully validate the quality of the image.

This change gives the user the ability to increase the size as part of this approval process.

![original-size](https://github.com/google-marketing-solutions/adios/assets/7289781/4f4843b5-30e4-44e9-80f0-c5bbfb7b9b9d)

![medium-size](https://github.com/google-marketing-solutions/adios/assets/7289781/1b2f6dfa-54f9-4b16-a776-cfe494847326)

![full-size](https://github.com/google-marketing-solutions/adios/assets/7289781/7b7a892b-1af4-47c0-906c-119434e262b2)
