### PR TITLE
Update google-ads-api.ts

### DIFF
--- a/src/google-ads-api.ts
+++ b/src/google-ads-api.ts
@@ -41,7 +41,7 @@ export class GoogleAdsApi implements GoogleAdsApiInterface {
       },
     };
     this._basePath =
-      'https://googleads.googleapis.com/v17/customers/' + this._customerId;
+      'https://googleads.googleapis.com/v20/customers/' + this._customerId;
   }
 
   _getResult(httpResponse: GoogleAppsScript.URL_Fetch.HTTPResponse) {


### PR DESCRIPTION
Updating the GAds API version to v20. V17 is no longer supported.