### PR TITLE
Added the ability to upload images to multiple accounts at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ Note: these features can be used separately, e.g. you can just upload images to 
 
 https://github.com/google-marketing-solutions/adios/assets/3335483/f22172d3-38f1-4fdb-b366-67a33700180e
 
+\*\* [Adios for multiple account upload sheet](https://docs.google.com/spreadsheets/d/1Rl340v76IMSC5eOAG31rq90TBtdbii_JZO88wSHHxHw/edit?resourcekey=0-hFnxlWeKbDqvgZtJke-KJQ&gid=528843970#gid=528843970)
+
 1. Make a copy of the [template Spreadsheet: Adios v1.3](https://docs.google.com/spreadsheets/d/1e4OXlUaAYI1B0n7j5WOGEbzNsmAAFfkGg8rXZXejk3c/edit?usp=sharing) (in the main menu `File > Make a copy`). Earlier versions:
 
    - [Adios v1.2](https://docs.google.com/spreadsheets/d/1DUNphGZIRL6mPDyrqgXErL-7p-gs0WmTqIjZl2ZXdSM/edit?usp=sharing)

--- a/src/config.ts
+++ b/src/config.ts
@@ -44,6 +44,7 @@ interface Config {
   'VertexAI Api Domain Part'?: string;
   'Gemini Model'?: string;
   'Image Generation Model'?: string;
+  'Additional Accounts For Upload'?: string;
 }
 
 export const sheet =
@@ -79,13 +80,14 @@ const DEFAULT_CONFIG = {
   'VertexAI Api Domain Part': undefined,
   'Gemini Model': undefined,
   'Image Generation Model': undefined,
+  'Additional Accounts For Upload': '',
 };
 
 export const ADIOS_MODES = {
   AD_GROUP: 'AdGroup Name',
   KEYWORDS: 'AdGroup Keywords',
 };
-export const ADIOS_MODE_CELL = 'B6';
+export const ADIOS_MODE_CELL = 'B7';
 
 export const CONFIG: Config =
   sheet

--- a/src/image-upload-service.ts
+++ b/src/image-upload-service.ts
@@ -73,6 +73,19 @@ export class ImageUploadService extends Triggerable {
         Logger.log('No images to upload.');
       } else {
         this._googleAdsApi.uploadImageAssets(images);
+        if (CONFIG['Additional Accounts For Upload']) {
+          const additionalAccounts = CONFIG['Additional Accounts For Upload']
+            .split(',')
+            .map(e => e.trim());
+          for (const account of additionalAccounts) {
+            const googleAdsApi = new GoogleAdsApi(
+              CONFIG['Ads API Key'],
+              CONFIG['Manager ID'],
+              account
+            );
+            googleAdsApi.uploadImageAssets(images);
+          }
+        }
         this._gcsApi.moveImages(
           CONFIG['Account ID'],
           adGroup.adGroup.id,

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -47,14 +47,14 @@ function onEdit(e: GoogleAppsScript.Events.SheetsOnEdit) {
 function toggleRows(adiosMode: string) {
   switch (adiosMode) {
     case ADIOS_MODES.AD_GROUP:
-      // Show rows 7,8. Hide rows 9,10,11
-      sheet.showRows(7, 2);
-      sheet.hideRows(9, 3);
+      // Show rows 8, 9. Hide rows 10, 11, 12
+      sheet.showRows(8, 2);
+      sheet.hideRows(10, 3);
       break;
     case ADIOS_MODES.KEYWORDS:
-      // Hide rows 7,8. Show rows 9,10,11
-      sheet.showRows(9, 3);
-      sheet.hideRows(7, 2);
+      // Hide rows 8, 9. Show rows 10, 11, 12
+      sheet.showRows(10, 3);
+      sheet.hideRows(8, 2);
       break;
     default:
       console.error(`Unknown mode: ${adiosMode}`);


### PR DESCRIPTION
The additional accounts must be provided in the Config sheet 'Additional Accounts For Upload' row, comma separated. 
The images marked as approved will be uploaded to the asset libraries in all accounts mentioned (Including original account from image generation process). 